### PR TITLE
add beforeRetryMethod parameter to RetryOnFailure

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,21 @@ class ExampleSpec extends Specification {
 It can be applied to a super class:
 ```groovy
 
-@RetryOnFailure(times=4)
+@RetryOnFailure
 class BaseSpec extends Specification {
-	
+    void beforeRetryAfterFailure(){
+       // will before every repeat of the test ( if child class will not override it )
+    }
 }
 
 class ChildSpec extends BaseSpec {
 	
 	void 'do something flaky'() {
 		// will try to run four times before failing
+	}
+	
+	void beforeRetryAfterFailure(){
+	   // will before every repeat of the test
 	}
 }
 ```
@@ -54,3 +60,6 @@ The `times` argument is optional; with none specified, the runner will attempt t
 The latest release of this extension works with Spock 1.0 and is available on [bintray](https://bintray.com/anotherchrisberry/spock-retry/spock-retry).
 
 If you are using Spock 0.7, you'll need to grab the code from the [initial commit](https://github.com/anotherchrisberry/spock-retry/tree/e3135038fb796b2c44efda3adc29970dc40b09d5). Sorry, I'm not sure the best way to go about this. You could grab the three files in [this directory](https://github.com/anotherchrisberry/spock-retry/tree/e3135038fb796b2c44efda3adc29970dc40b09d5/src/main/groovy/com/anotherchrisberry/spock/extensions/retry) and include them in your project.
+
+
+  

--- a/src/main/groovy/com/anotherchrisberry/spock/extensions/retry/RetryInterceptor.groovy
+++ b/src/main/groovy/com/anotherchrisberry/spock/extensions/retry/RetryInterceptor.groovy
@@ -11,6 +11,8 @@ class RetryInterceptor implements IMethodInterceptor {
 
     static Logger LOG = LoggerFactory.getLogger(RetryInterceptor.class);
 
+    private static final String BEFORE_RETRY_METHOD_NAME = "beforeRetry"
+
     Integer retryMax
 
     RetryInterceptor(int retryMax) {
@@ -47,6 +49,15 @@ class RetryInterceptor implements IMethodInterceptor {
                         // increment counter, since this is the start of the re-run
                         attempts++
                         LOG.info("Retry caught failure ${attempts + 1} / ${retryMax + 1} while setting up", t2)
+                    }
+                }
+
+                if(invocation.target.respondsTo(BEFORE_RETRY_METHOD_NAME)) {
+                    try {
+                        invocation.target."$BEFORE_RETRY_METHOD_NAME"()
+                    } catch (Throwable t2) {
+                        // increment counter, since this is the start of the re-run
+                        LOG.info("Retry caught failure when invoking $BEFORE_RETRY_METHOD_NAME ", t2)
                     }
                 }
             }

--- a/src/test/groovy/com/anotherchrisberry/spock/extensions/retry/RetryOnFailureBeforeRetryMethod.groovy
+++ b/src/test/groovy/com/anotherchrisberry/spock/extensions/retry/RetryOnFailureBeforeRetryMethod.groovy
@@ -1,0 +1,26 @@
+package com.anotherchrisberry.spock.extensions.retry
+
+import spock.lang.Specification
+
+class RetryOnFailureBeforeRetryMethod extends Specification{
+
+    static Integer classLevelTries = 0
+    static Integer onRetry = 0
+
+    @RetryOnFailure(times=3)
+    void 'expect beforeRetry method is called once'() {
+
+        when:
+        if (classLevelTries < 1) {
+            classLevelTries ++
+            throw new RuntimeException('no problem')
+        }
+
+        then:
+        onRetry == 1
+    }
+
+    void beforeRetry(){
+        onRetry ++
+    }
+}


### PR DESCRIPTION
I needed a method that would be invoked before another try of running integration test.

Use Case:
1. your test fails from time to time but when it fails remaining tests will fail too
2. before you retry you need to have environment in a certain condition ( restart services, restart OS for Selenium IEDriver ... whatever )
3. The step 2 is quicker than re running whole suite again

Notice:
The change slightly changes ( I would say fixes ) using default value of retry from System.properties  ( test adjusted )
