### PR TITLE
fail on retry when setup throws exception

### DIFF
--- a/src/main/groovy/com/anotherchrisberry/spock/extensions/retry/RetryInterceptor.groovy
+++ b/src/main/groovy/com/anotherchrisberry/spock/extensions/retry/RetryInterceptor.groovy
@@ -56,6 +56,9 @@ class RetryInterceptor implements IMethodInterceptor {
                         } catch (Throwable t2) {
                             // increment counter, since this is the start of the re-run
                             attempts++
+                            if (attempts > retryMax) {
+                                throw t
+                            }
                             LOG.info("Retry caught failure ${attempts + 1} / ${retryMax + 1} while setting up", t2)
                         }
                     }

--- a/src/test/groovy/com/anotherchrisberry/spock/extensions/retry/RetryOnFailureSetupSingleSpec.groovy
+++ b/src/test/groovy/com/anotherchrisberry/spock/extensions/retry/RetryOnFailureSetupSingleSpec.groovy
@@ -1,0 +1,18 @@
+package com.anotherchrisberry.spock.extensions.retry
+
+import spock.lang.Ignore
+import spock.lang.Specification
+
+@RetryOnFailure
+class RetryOnFailureSetupSingleSpec extends Specification {
+
+    void setup() {
+        throw new RuntimeException("setup failed")
+    }
+
+    @Ignore
+    void 'should fail when setup fails once'() {
+        given:
+        throw new Exception("spec itself failed")
+    }
+}


### PR DESCRIPTION
I can't find a good way to test this, unfortunately, so just including a test that reproduces the underlying issue (https://github.com/anotherchrisberry/spock-retry/issues/20) and `@Ignore`ing it.

The problem is we increment run attempts when setup fails, but don't check to see if we should throw the exception after this attempt. If `times` is not explicitly set to something greater than 1, we will have incremented the run attempts twice, and thus the test will be marked as successful.