### PR TITLE
Fixes #23: Ignore JUnit's AssumptionViolatedException

### DIFF
--- a/src/main/groovy/com/anotherchrisberry/spock/extensions/retry/RetryInterceptor.groovy
+++ b/src/main/groovy/com/anotherchrisberry/spock/extensions/retry/RetryInterceptor.groovy
@@ -27,6 +27,8 @@ class RetryInterceptor implements IMethodInterceptor {
             try {
                 invocation.proceed()
                 attempts = retryMax + 1
+            } catch (org.junit.AssumptionViolatedException e) {
+                throw e
             } catch (Throwable t) {
                 LOG.info("Retry caught failure ${attempts + 1} / ${retryMax + 1}: ", t)
                 attempts++


### PR DESCRIPTION
This pull request causes JUnit's `AssumptionViomatedException` to be propagated up with any retries occurring. This causes the test to be ignored without any retries being made.