### PR TITLE
clear system property in cleanupSpec

### DIFF
--- a/src/main/groovy/com/anotherchrisberry/spock/extensions/retry/RetryInterceptor.groovy
+++ b/src/main/groovy/com/anotherchrisberry/spock/extensions/retry/RetryInterceptor.groovy
@@ -1,5 +1,6 @@
 package com.anotherchrisberry.spock.extensions.retry
 
+import org.junit.AssumptionViolatedException
 import org.spockframework.runtime.extension.IMethodInterceptor
 import org.spockframework.runtime.extension.IMethodInvocation
 import org.spockframework.util.ReflectionUtil
@@ -9,7 +10,7 @@ import org.slf4j.LoggerFactory;
 
 class RetryInterceptor implements IMethodInterceptor {
 
-    static Logger LOG = LoggerFactory.getLogger(RetryInterceptor.class);
+    static Logger LOG = LoggerFactory.getLogger(RetryInterceptor.class)
 
     private static final String BEFORE_RETRY_METHOD_NAME = "beforeRetry"
 
@@ -27,7 +28,7 @@ class RetryInterceptor implements IMethodInterceptor {
             try {
                 invocation.proceed()
                 attempts = retryMax + 1
-            } catch (org.junit.AssumptionViolatedException e) {
+            } catch (AssumptionViolatedException e) {
                 throw e
             } catch (Throwable t) {
                 LOG.info("Retry caught failure ${attempts + 1} / ${retryMax + 1}: ", t)

--- a/src/test/groovy/com/anotherchrisberry/spock/extensions/retry/RetryOnFailureSuperclassSpec.groovy
+++ b/src/test/groovy/com/anotherchrisberry/spock/extensions/retry/RetryOnFailureSuperclassSpec.groovy
@@ -11,7 +11,7 @@ class RetryOnFailureSuperclassSpec extends Specification {
         when:
         if (retryCount < 9) {
             retryCount++
-            throw new RuntimeException('not there yet')
+            throw new RuntimeException("not there yet: ${retryCount}")
         }
 
         then:

--- a/src/test/groovy/com/anotherchrisberry/spock/extensions/retry/RetryOnFailureWithSystemPropertySpec.groovy
+++ b/src/test/groovy/com/anotherchrisberry/spock/extensions/retry/RetryOnFailureWithSystemPropertySpec.groovy
@@ -13,6 +13,10 @@ class RetryOnFailureWithSystemPropertySpec extends Specification {
         System.setProperty("spock-retry.times", "5")
     }
 
+    void cleanupSpec() {
+        System.clearProperty("spock-retry.times")
+    }
+
     void 'class level test'() {
         when:
         if (classLevelTries < 5) {


### PR DESCRIPTION
Bit of formatting cleanup, plus removing a system property that is being set by a different test and causing grief when running a simple `gradle test` or letting Travis do its thing.

Thanks @doumdoum for pointing that out!